### PR TITLE
Add Strigo exercises configuration

### DIFF
--- a/.strigo/config.yml
+++ b/.strigo/config.yml
@@ -1,0 +1,19 @@
+# Class exercises - configuration for single class
+---
+classes:
+  - exercises:
+      # `file` is relative to .strigo directory
+      - file: "../README.md"
+        title: "Introduction"
+      - file: "../setup/README.md"
+        title: "Software Prerequisites Setup and Environment Validation"
+      - file: "../complete/petclinic-jdbc/README.md"
+        title: "Spring Boot famous PetClinic sample with JDBC persistence"
+      - file: "../graalvm/README.md"
+        title: "Understanding GraalVM"
+      - file: "../spring-native/README.md"
+        title: "Building Spring Native Applications"
+      - file: "../best-practices/README.md"
+        title: "Best practices for Troubleshooting and Designing Native-friendly Spring apps / libraries"
+      - file: "../complete/README.md"
+        title: "Complete Spring Native examples"


### PR DESCRIPTION
Hi Dan. Continuing our email chat, this PR will add the configuration required by Strigo, so we can fetch the materials here as exercises to your class. Please let me know if it has a wrong order or requires any change.

Once it is merged and the new management Strigo console is enabled for you, you will be able to fetch them all and it will look like this for your learners:

![image](https://user-images.githubusercontent.com/6122352/128385210-2f8592a5-a0c1-42bd-8fe3-9b8cd3875671.png)
